### PR TITLE
Fix: GSoC link fix on mobile menu

### DIFF
--- a/_includes/main-menu-mobile.html
+++ b/_includes/main-menu-mobile.html
@@ -1,9 +1,12 @@
 <div id="main-menu-mobile" class="main-menu-mobile">
-  {% assign mainmenu = site.data.menus.main | sort: 'weight'  %}
   <ul>
     {% for item in mainmenu %}
     <li class="{% if item.url == page.url %}active{% endif %}">
+      {% if item.url == '/gsoc24' %}
+      <a href="/gsoc"  >GSoC 24</a>
+      {% else %}
       <a href="{{ item.url | relative_url }}">{{ item.name }}</a>
+      {% endif %}
     </li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
When navigating through the main menu on the mobile, Selecting the "GSoC 24" was not navigating to correct link.

Correct Behavior:
The user is now directed to the correct link - /gsoc


