### PR TITLE
Fix: Make header sticky for improved navigation and user experience

### DIFF
--- a/_sass/components/_header.scss
+++ b/_sass/components/_header.scss
@@ -7,6 +7,10 @@
   // box-shadow: 0 1px 15px rgba(50, 50, 93, 0.2);
   border-bottom: 1px solid $white-offset;
   padding: 10px 0px;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  width: 100%;
   .container {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
### Summary
This PR fixes the issue where the header was not sticky and would disappear when scrolling down the page. This required users to scroll back to the top repeatedly to access navigation links, negatively impacting usability.

closes #14 

The header is now sticky and remains visible at the top of the screen while scrolling, ensuring seamless navigation across all sections.

### Before:
[Screencast from 2026-02-20 02-07-50.webm](https://github.com/user-attachments/assets/e88be03d-5709-45a3-a6f9-1f728ab4db18)
### Now:
https://github.com/user-attachments/assets/154fdd89-ec65-4f90-8e00-5c284f9cb5cc

### Changes Made
- Added sticky positioning to the header
- Ensured proper stacking order using z-index
- Maintained full width to prevent layout shifts

### Implementation
```css
header {
  position: sticky;
  top: 0;
  z-index: 1000;
  width: 100%;
}



