### PR TITLE
Fix accordion icon state to match expanded/collapsed panels

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -15,7 +15,8 @@ for (i = 0; i < acc.length; i++) {
   // Expand the panel by default
   var panel = acc[i].nextElementSibling;
   panel.style.maxHeight = panel.scrollHeight + "px";
-  
+  acc[i].classList.add("active");
+
   acc[i].addEventListener("click", function() {
     this.classList.toggle("active");
     var panel = this.nextElementSibling;


### PR DESCRIPTION
Fixes https://github.com/c2siorg/c2siorg.github.io/issues/16

# Before
The icons on the right are semantically incorrect here.

<img width="1182" height="433" alt="image" src="https://github.com/user-attachments/assets/cdceeb72-82f1-4c97-ac41-c7a4662000c2" />

# After
Just reversed the logic here. Now it makes more sense.

<img width="1166" height="469" alt="image" src="https://github.com/user-attachments/assets/ae5525b7-4c92-4b89-9f27-3035c576d475" />
