### PR TITLE
chore: remove leftover console debug logs from accordion script

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -1,3 +1,4 @@
+
 var body = document.querySelector('body')
 var menuTrigger = document.querySelector('#toggle-main-menu-mobile');
 var menuContainer = document.querySelector('#main-menu-mobile');
@@ -22,10 +23,8 @@ for (i = 0; i < acc.length; i++) {
     var panel = this.nextElementSibling;
     if (panel.style.maxHeight) {
       panel.style.maxHeight = null;
-      console.log("if");
     } else {
       panel.style.maxHeight = panel.scrollHeight + "px";
-      console.log("else");
     } 
   });
 


### PR DESCRIPTION
This PR removes two console.log statements from the accordion toggle logic in scripts.js.

These logs were printing "if" and "else" in the browser console when the accordion was clicked. They are not needed for functionality.

No other changes were made. The accordion behavior remains the same.